### PR TITLE
remove debug messages in busy loop

### DIFF
--- a/message_processor.go
+++ b/message_processor.go
@@ -99,8 +99,6 @@ func (mg messageProcessor) sendMessage(l logger.Logger, buf *logdriver.LogEntry,
 	// Only send if partial bit is not set or temp buffer size reached max or temp buffer timer expired
 	// Check for temp buffer timer expiration
 	if !buf.Partial || t.shouldFlush(time.Now()) {
-		logrus.WithField("id", containerid).WithField("Buffer partial flag should be false:",
-			buf.Partial).WithField("Temp buffer Length:", t.tBuf.Len()).Debug("Buffer details")
 		msg.Line = t.tBuf.Bytes()
 		msg.Source = buf.Source
 		msg.Partial = buf.Partial

--- a/partial_message_buffer.go
+++ b/partial_message_buffer.go
@@ -50,7 +50,6 @@ func (b *partialMsgBuffer) append(l *logdriver.LogEntry) (err error) {
 
 func (b *partialMsgBuffer) reset() {
 	if b.bufferReset {
-		logrus.Debug("Resetting temp buffer")
 		b.tBuf.Reset()
 		b.bufferTimer = time.Now()
 	}


### PR DESCRIPTION
In perf test, the debug messages are printed too much and caused plugin log loss in docker daemon.